### PR TITLE
Ruby backwards compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 
 rvm:
   - 2.3.0
+  - 2.0.0-p598 # CentOS 7
+  - 2.1.5 # Debian 8
 
 cache:
   - bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Kolekti Radon is the metric collector for Python using the radon library.
 
+## Unreleased
+
+Support Ruby 2.0.0 and 2.1.5
+
 ## v0.0.1 - 06/05/2016
 
 Initial release

--- a/gem_tasks/cucumber.rake
+++ b/gem_tasks/cucumber.rake
@@ -3,25 +3,8 @@
 require 'cucumber/rake/task'
 require 'cucumber/platform'
 
-class Cucumber::Rake::Task
-  def set_profile_for_current_ruby
-    self.profile = if Cucumber::JRUBY
-      Cucumber::WINDOWS ? 'jruby_win' : 'jruby'
-    elsif Cucumber::WINDOWS_MRI
-      'windows_mri'
-    elsif Cucumber::RUBY_1_9
-      'ruby_1_9'
-    elsif Cucumber::RUBY_2_0
-      'ruby_2_0'
-    elsif Cucumber::RUBY_2_1
-      'ruby_2_1'
-    end
-  end
-end
-
 Cucumber::Rake::Task.new(:features) do |t|
   t.fork = true
-  t.set_profile_for_current_ruby
 end
 
 task :cucumber => :features

--- a/lib/kolekti/radon/collector.rb
+++ b/lib/kolekti/radon/collector.rb
@@ -4,7 +4,9 @@ module Kolekti
   module Radon
     class Collector < Kolekti::Collector
       def self.available?
-        system('radon', '--version', [:out, :err] => '/dev/null') ? true : false
+        # FIXME: below is the better form of writing this, but it does not look compatible with ruby 2.1.5 and 2.0.0
+        # system('radon', '--version', [:out, :err] => '/dev/null') ? true : false
+        system('radon', '--version', out: '/dev/null', err: '/dev/null') ? true : false
       end
 
       def self.logger

--- a/spec/kolekti/radon/collector_spec.rb
+++ b/spec/kolekti/radon/collector_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Kolekti::Radon::Collector do
   describe 'class method' do
     describe 'available?' do
-      let(:command_params){ ['radon', '--version', [:out, :err] => '/dev/null'] }
+      let(:command_params){ ['radon', '--version', out: '/dev/null', err: '/dev/null'] }
 
       context 'with a successful call (system exit 0)' do
         it 'is expected to call the system executable and return true' do


### PR DESCRIPTION
Adds compatibility with Ruby 2.0.0 and 2.1.5, by also building against those versions.

This is heavily based on the previous experience at [Kolekti MetricFu](https://github.com/mezuro/kolekti_metricfu/pull/15).

It should fix the following build https://travis-ci.org/mezuro/kalibro_processor/jobs/131760714.
